### PR TITLE
rails3 escape

### DIFF
--- a/lib/country_code_select/instance_tag.rb
+++ b/lib/country_code_select/instance_tag.rb
@@ -17,7 +17,7 @@ module CountryCodeSelect
 			end
 
 			countries = countries + options_for_select(COUNTRIES, selected)
-   		content_tag(:select, countries, options.merge(:id => "#{@object_name}_#{@method_name}", :name => "#{@object_name}[#{@method_name}]"))
+   		content_tag(:select, countries, options.merge(:id => "#{@object_name}_#{@method_name}", :name => "#{@object_name}[#{@method_name}]"),false)
 		end
 	end
 end


### PR DESCRIPTION
Hello
I disable escape for content_tag - it is require for rails3
